### PR TITLE
VSeeFace update to 1.13.38b3

### DIFF
--- a/vseeface.json
+++ b/vseeface.json
@@ -3,11 +3,11 @@
         "github": "https://github.com/emilianavt/VSeeFaceReleases"
     },
     "autoupdate": {
-        "url": "https://github.com/emilianavt/VSeeFaceReleases/releases/download/v$version/VSeeFace-v$version.zip"
+        "url": "https://github.com/emilianavt/VSeeFaceReleases/releases/download/v$majorVersion/VSeeFace-v$version.zip"
     },
-    "version": "1.13.38",
-    "url": "https://github.com/emilianavt/VSeeFaceReleases/releases/download/v1.13.38/VSeeFace-v1.13.38.zip",
-    "hash": "dd56e85bf6b709b20ab50ef899cfe89f560431aa3221ee23ecb4cfd885881efc",
+    "version": "1.13.38b3",
+    "url": "https://github.com/emilianavt/VSeeFaceReleases/releases/download/v1.13.38b/VSeeFace-v1.13.38b3.zip",
+    "hash": "29199A92A125F5C59B3901B4781492211E223CCD5E5085B9385743D126F1F7B5",
     "extract_dir": "VSeeFace",
     "bin": "VSeeFace.exe",
     "shortcuts": [


### PR DESCRIPTION
Quirky version numbers should also now work for autoupdates.
I tested if it successfully installs from my forked repository, it does :)